### PR TITLE
feat: 添加活跃度惩罚机制

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ on_command("淫趴介绍", priority=20, block=True)
 指令9: 淫趴介绍  (输出淫趴插件的命令列表)
 
 ### env配置项:
-| config     | type | default | example           | usage      |
-| ---------- | ---- | ------- | ----------------- | ---------- |
-| djCDtime   | int  | 300     | djCDtime = 300    | 打胶的CD   |
-| pkCDTime   | int  | 60      | pkCDTime = 60     | pk的CD     |
-| suoCDTime  | int  | 300     | suoCDTime = 300   | 嗦牛子的CD |
-| fuckCDTime | int  | 3600    | fuckCDTime = 3600 | 透群友的CD |
+| config       | type | default | example              | usage      |
+| ------------ | ---- | ------- | -------------------- | ---------- |
+| djCDtime     | int  | 300     | djCDtime = 300       | 打胶的CD   |
+| pkCDTime     | int  | 60      | pkCDTime = 60        | pk的CD     |
+| suoCDTime    | int  | 300     | suoCDTime = 300      | 嗦牛子的CD |
+| fuckCDTime   | int  | 3600    | fuckCDTime = 3600    | 透群友的CD |
+| isalive      | bool | False   | isalive = True       | 不活跃惩罚 |
+| reset_impact | bool | False   | reset_impact = False | 清除昨日活跃 |
 
-以上配置项单位均为秒, 大小写不敏感(反正env里面拿到dict都是小写的key)
+以上配置项单位为秒或bool值, 大小写不敏感(反正env里面拿到dict都是小写的key)

--- a/nonebot_plugin_impact/__init__.py
+++ b/nonebot_plugin_impact/__init__.py
@@ -8,6 +8,14 @@ from nonebot.permission import SUPERUSER
 from .handle import impart
 from .utils import utils
 
+from nonebot import require
+
+require("nonebot_plugin_apscheduler")
+
+from nonebot_plugin_apscheduler import scheduler
+
+scheduler.add_job(impart.penalties_and_resets, "cron", hour = 0, misfire_grace_time = 600)
+
 on_command(
     "pk",
     aliases={"对决"},

--- a/nonebot_plugin_impact/handle.py
+++ b/nonebot_plugin_impact/handle.py
@@ -387,7 +387,7 @@ class Impart:
         utils.isdailyalive_data[utils.get_today()][uid]["usage"] +=1
         utils.write_isdailyalive()
         # 准备调用api, 用来获取头像
-        repo_1 = f"好欸！{req_user_card}({uid})用时{random.randint(1, 21600)}秒 \n给 {lucky_user_card}({lucky_user}) 注入了{ejaculation}毫升的脱氧核糖核酸, 当日总注入量为：{utils.get_today_ejaculation(lucky_user)}"
+        repo_1 = f"好欸！{req_user_card}({uid})用时{random.randint(1, 20)}秒 \n给 {lucky_user_card}({lucky_user}) 注入了{ejaculation}毫升的脱氧核糖核酸, 当日总注入量为：{utils.get_today_ejaculation(lucky_user)}"
         await matcher.send(
             repo_1
             + MessageSegment.image(f"https://q1.qlogo.cn/g?b=qq&nk={lucky_user}&s=640")


### PR DESCRIPTION
自行进行打胶/嗦牛子/PK/透XX的时候会加活跃度，他人给嗦牛子也会增加活跃度
每天零点对昨日活跃度进行清算，活跃度为0的会受到长度减少0-1的惩罚，长度低于1的将不会受到惩罚（限制1.001是避免精度问题导致出现负值）
也可以在完成操作后自动清除昨日的活跃度